### PR TITLE
Add generic object datatype

### DIFF
--- a/assets/dataType.go
+++ b/assets/dataType.go
@@ -1,8 +1,10 @@
 package assets
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -156,6 +158,35 @@ var dataTypeMap = map[string]*DataType{
 			}
 
 			return dataTime.Format(time.RFC3339), dataTime, nil
+		},
+	},
+	"@object": {
+		AcceptedFormats: []string{"@object"},
+		Parse: func(data interface{}) (string, interface{}, errors.ICCError) {
+			dataVal, ok := data.(map[string]interface{})
+			if !ok {
+				switch v := data.(type) {
+				case []byte:
+					err := json.Unmarshal(v, &dataVal)
+					if err != nil {
+						return "", nil, errors.WrapErrorWithStatus(err, "failed to unmarshal []byte into map[string]interface{}", http.StatusBadRequest)
+					}
+				case string:
+					err := json.Unmarshal([]byte(v), &dataVal)
+					if err != nil {
+						return "", nil, errors.WrapErrorWithStatus(err, "failed to unmarshal string into map[string]interface{}", http.StatusBadRequest)
+					}
+				default:
+					return "", nil, errors.NewCCError(fmt.Sprintf("asset property must be either a byte array or a string, but received type is: %T", data), http.StatusBadRequest)
+				}
+			}
+
+			retVal, err := json.Marshal(dataVal)
+			if err != nil {
+				return "", nil, errors.WrapErrorWithStatus(err, "failed to marshal return value", http.StatusInternalServerError)
+			}
+
+			return string(retVal), dataVal, nil
 		},
 	},
 }

--- a/test/chaincode_test.go
+++ b/test/chaincode_test.go
@@ -65,6 +65,12 @@ var testAssetList = []assets.AssetType{
 				DefaultValue: 0,
 				DataType:     "number",
 			},
+			{
+				// Generic JSON object
+				Tag:      "info",
+				Label:    "Other Info",
+				DataType: "@object",
+			},
 		},
 	},
 	{

--- a/test/tx_createAsset_test.go
+++ b/test/tx_createAsset_test.go
@@ -16,6 +16,9 @@ func TestCreateAsset(t *testing.T) {
 		"@assetType": "person",
 		"name":       "Maria",
 		"id":         "318.207.920-48",
+		"info": map[string]interface{}{
+			"passport": "1234",
+		},
 	}
 	req := map[string]interface{}{
 		"asset": []map[string]interface{}{person},
@@ -39,6 +42,9 @@ func TestCreateAsset(t *testing.T) {
 		"name":         "Maria",
 		"id":           "31820792048",
 		"height":       0.0,
+		"info": map[string]interface{}{
+			"passport": "1234",
+		},
 	}
 
 	if res.GetStatus() != 200 {

--- a/test/tx_getDataTypes_test.go
+++ b/test/tx_getDataTypes_test.go
@@ -45,6 +45,12 @@ func TestGetDataTypes(t *testing.T) {
 			},
 			"DropDownValues": nil,
 		},
+		"@object": map[string]interface{}{
+			"acceptedFormats": []interface{}{
+				"@object",
+			},
+			"DropDownValues": nil,
+		},
 	}
 	err := invokeAndVerify(stub, "getDataTypes", nil, expectedResponse, 200)
 	if err != nil {

--- a/test/tx_getSchema_test.go
+++ b/test/tx_getSchema_test.go
@@ -99,6 +99,16 @@ func TestGetSchema(t *testing.T) {
 				"tag":          "height",
 				"writers":      nil,
 			},
+			map[string]interface{}{
+				"dataType":    "@object",
+				"description": "",
+				"isKey":       false,
+				"label":       "Other Info",
+				"readOnly":    false,
+				"required":    false,
+				"tag":         "info",
+				"writers":     nil,
+			},
 		},
 	}
 	err = invokeAndVerify(stub, "getSchema", req, expectedPersonSchema, 200)

--- a/test/tx_updateAsset_test.go
+++ b/test/tx_updateAsset_test.go
@@ -39,6 +39,7 @@ func TestUpdateAsset(t *testing.T) {
 		"id":          "318.207.920-48",
 		"dateOfBirth": "1999-05-06T22:12:41Z",
 		"height":      1.66,
+		"info":        map[string]interface{}{},
 	}
 
 	req := map[string]interface{}{


### PR DESCRIPTION
Tested with cc-tools CRUD operations and looks fine. Object can be sent either as a nested object or a JSON string.

```json
"object": "{\"key1\": \"value1\", \"key2\": \"value2\"}"
```

```json
"object": {
		"key1": "value1",
		"key2": "value2"
	}
```