### PR TITLE
Fix recursive search for @object properties

### DIFF
--- a/assets/dataType.go
+++ b/assets/dataType.go
@@ -181,6 +181,8 @@ var dataTypeMap = map[string]*DataType{
 				}
 			}
 
+			dataVal["@assetType"] = "@object"
+
 			retVal, err := json.Marshal(dataVal)
 			if err != nil {
 				return "", nil, errors.WrapErrorWithStatus(err, "failed to marshal return value", http.StatusInternalServerError)

--- a/assets/get.go
+++ b/assets/get.go
@@ -164,6 +164,11 @@ func getRecursive(stub *sw.StubWrapper, pvtCollection, key string, keysChecked [
 	for k, v := range response {
 		switch prop := v.(type) {
 		case map[string]interface{}:
+
+			if prop["@assetType"].(string) == "@object" {
+				continue
+			}
+
 			propKey, err := NewKey(prop)
 			if err != nil {
 				return nil, errors.WrapErrorWithStatus(err, "failed to resolve asset references", 500)
@@ -205,6 +210,11 @@ func getRecursive(stub *sw.StubWrapper, pvtCollection, key string, keysChecked [
 		case []interface{}:
 			for idx, elem := range prop {
 				if elemMap, ok := elem.(map[string]interface{}); ok {
+
+					if elemMap["@assetType"].(string) == "@object" {
+						continue
+					}
+
 					elemKey, err := NewKey(elemMap)
 					if err != nil {
 						return nil, errors.WrapErrorWithStatus(err, "failed to resolve asset references", 500)

--- a/stubwrapper/stubWrapper.go
+++ b/stubwrapper/stubWrapper.go
@@ -201,3 +201,12 @@ func (sw *StubWrapper) GetMSPID() (string, errors.ICCError) {
 	}
 	return mspid, nil
 }
+
+// SplitCompositeKey returns composite keys
+func (sw *StubWrapper) SplitCompositeKey(compositeKey string) (string, []string, errors.ICCError) {
+	key, keys, err := sw.Stub.SplitCompositeKey(compositeKey)
+	if err != nil {
+		return "", nil, errors.WrapError(err, "stub.SplitCompositeKey call error")
+	}
+	return key, keys, nil
+}

--- a/test/tx_createAsset_test.go
+++ b/test/tx_createAsset_test.go
@@ -43,7 +43,8 @@ func TestCreateAsset(t *testing.T) {
 		"id":           "31820792048",
 		"height":       0.0,
 		"info": map[string]interface{}{
-			"passport": "1234",
+			"@assetType": "@object",
+			"passport":   "1234",
 		},
 	}
 


### PR DESCRIPTION
* Add `@object` as `@assetType` for `@object` datatype. This allows for verification when resolving properties that are `map[string]interface{}`. `@objects` should not be resolved.