### PR TITLE
Events funcionality

### DIFF
--- a/events/event.go
+++ b/events/event.go
@@ -53,6 +53,7 @@ type Event struct {
 	Chaincode string `json:"chaincode"`
 
 	// CustomFunction is used an event of type "EventCustom" is called.
+	// It is a function that receives a stub and a payload and returns an error.
 	CustomFunction func(*sw.StubWrapper, []byte) error `json:"-"`
 }
 

--- a/events/event.go
+++ b/events/event.go
@@ -27,6 +27,9 @@ type Event struct {
 	// Description is a simple explanation describing the meaning of the event.
 	Description string `json:"description"`
 
+	// BaseLog is the basisc log message for the event
+	BaseLog string `json:"baseLog"`
+
 	// Type is the type of event
 	Type EventType `json:"type"`
 

--- a/events/event.go
+++ b/events/event.go
@@ -56,7 +56,7 @@ type Event struct {
 	// It is a function that receives a stub and a payload and returns an error.
 	CustomFunction func(*sw.StubWrapper, []byte) error `json:"-"`
 
-	// ReadOnly indicates if the CustomFunction has the ability to alter the world state (if of type EventTransaction).
+	// ReadOnly indicates if the CustomFunction has the ability to alter the world state (if of type EventCustom).
 	ReadOnly bool `json:"readOnly"`
 }
 

--- a/events/event.go
+++ b/events/event.go
@@ -30,6 +30,14 @@ type Event struct {
 	// Type is the type of event
 	Type EventType `json:"type"`
 
+	// Receivers is an array that specifies which organizations will receive the event.
+	// Accepts either basic strings for exact matches
+	// eg. []string{'org1MSP', 'org2MSP'}
+	// or regular expressions
+	// eg. []string{`$org\dMSP`} and cc-tools will
+	// check for a match with regular expression `org\dMSP`
+	Receivers []string `json:"receivers,omitempty"`
+
 	// Transaction is the transaction that the event triggers (if of type EventTransaction)
 	Transaction string `json:"transaction"`
 
@@ -41,13 +49,8 @@ type Event struct {
 	// If empty, the event will trigger on the same chaincode as the transaction that calls the event
 	Chaincode string `json:"chaincode"`
 
-	// Receivers is an array that specifies which organizations will receive the event.
-	// Accepts either basic strings for exact matches
-	// eg. []string{'org1MSP', 'org2MSP'}
-	// or regular expressions
-	// eg. []string{`$org\dMSP`} and cc-tools will
-	// check for a match with regular expression `org\dMSP`
-	Receivers []string `json:"receivers,omitempty"`
+	// CustomFunction is used an event of type "EventCustom" is called.
+	CustomFunction func([]byte) error `json:"-"`
 }
 
 func (event Event) CallEvent(stub *sw.StubWrapper, payload []byte) errors.ICCError {

--- a/events/event.go
+++ b/events/event.go
@@ -1,0 +1,69 @@
+package events
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/goledgerdev/cc-tools/errors"
+	sw "github.com/goledgerdev/cc-tools/stubwrapper"
+)
+
+type EventType float64
+
+const (
+	EventLog EventType = iota
+	EventTransaction
+	EventCustom
+)
+
+// Event is the struct defining a primitive event.
+type Event struct {
+	// Tag is how the event will be referenced
+	Tag string `json:"tag"`
+
+	// Label is the pretty event name for logs
+	Label string `json:"label"`
+
+	// Description is a simple explanation describing the meaning of the event.
+	Description string `json:"description"`
+
+	// Type is the type of event
+	Type EventType `json:"type"`
+
+	// Transaction is the transaction that the event triggers (if of type EventTransaction)
+	Transaction string `json:"transaction"`
+
+	// Channel is the channel of the transaction that the event triggers (if of type EventTransaction)
+	// If empty, the event will trigger on the same channel as the transaction that calls the event
+	Channel string `json:"channel"`
+
+	// Chaincode is the chaincode of the transaction that the event triggers (if of type EventTransaction)
+	// If empty, the event will trigger on the same chaincode as the transaction that calls the event
+	Chaincode string `json:"chaincode"`
+
+	// Receivers is an array that specifies which organizations will receive the event.
+	// Accepts either basic strings for exact matches
+	// eg. []string{'org1MSP', 'org2MSP'}
+	// or regular expressions
+	// eg. []string{`$org\dMSP`} and cc-tools will
+	// check for a match with regular expression `org\dMSP`
+	Receivers []string `json:"receivers,omitempty"`
+}
+
+func (event Event) CallEvent(stub *sw.StubWrapper, payload []byte) errors.ICCError {
+	err := stub.SetEvent(event.Tag, payload)
+	if err != nil {
+		return errors.WrapError(err, "stub.SetEvent call error")
+	}
+
+	return nil
+}
+
+func CallEvent(stub *sw.StubWrapper, eventTag string, payload []byte) errors.ICCError {
+	event := FetchEvent(eventTag)
+	if event == nil {
+		return errors.NewCCError(fmt.Sprintf("event named %s does not exist", eventTag), http.StatusBadRequest)
+	}
+
+	return event.CallEvent(stub, payload)
+}

--- a/events/event.go
+++ b/events/event.go
@@ -55,6 +55,9 @@ type Event struct {
 	// CustomFunction is used an event of type "EventCustom" is called.
 	// It is a function that receives a stub and a payload and returns an error.
 	CustomFunction func(*sw.StubWrapper, []byte) error `json:"-"`
+
+	// ReadOnly indicates if the CustomFunction has the ability to alter the world state (if of type EventTransaction).
+	ReadOnly bool `json:"readOnly"`
 }
 
 func (event Event) CallEvent(stub *sw.StubWrapper, payload []byte) errors.ICCError {

--- a/events/event.go
+++ b/events/event.go
@@ -53,7 +53,7 @@ type Event struct {
 	Chaincode string `json:"chaincode"`
 
 	// CustomFunction is used an event of type "EventCustom" is called.
-	CustomFunction func([]byte) error `json:"-"`
+	CustomFunction func(*sw.StubWrapper, []byte) error `json:"-"`
 }
 
 func (event Event) CallEvent(stub *sw.StubWrapper, payload []byte) errors.ICCError {

--- a/events/eventList.go
+++ b/events/eventList.go
@@ -1,0 +1,26 @@
+package events
+
+// eventList is the list which should contain all defined events
+var eventList = []Event{}
+
+// EventList returns a copy of the eventList variable.
+func EventList() []Event {
+	listCopy := make([]Event, len(eventList))
+	copy(listCopy, eventList)
+	return listCopy
+}
+
+// InitEventList appends custom events to eventList to avoid initialization loop.
+func InitEventList(l []Event) {
+	eventList = l
+}
+
+// FetchEvent returns a pointer to the event object or nil if event is not found.
+func FetchEvent(eventTag string) *Event {
+	for _, event := range eventList {
+		if event.Tag == eventTag {
+			return &event
+		}
+	}
+	return nil
+}

--- a/stubwrapper/stubWrapper.go
+++ b/stubwrapper/stubWrapper.go
@@ -210,3 +210,12 @@ func (sw *StubWrapper) SplitCompositeKey(compositeKey string) (string, []string,
 	}
 	return key, keys, nil
 }
+
+func (sw *StubWrapper) SetEvent(name string, payload []byte) errors.ICCError {
+	err := sw.Stub.SetEvent(name, payload)
+	if err != nil {
+		return errors.WrapError(err, "stub.SetEvent call error")
+	}
+
+	return nil
+}

--- a/test/assets_events_test.go
+++ b/test/assets_events_test.go
@@ -1,0 +1,33 @@
+package test
+
+import (
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/goledgerdev/cc-tools/events"
+)
+
+func TestFetchEvent(t *testing.T) {
+	event := *events.FetchEvent("createLibraryLog")
+	expectedEvent := testEventTypeList[0]
+
+	if !reflect.DeepEqual(event, expectedEvent) {
+		log.Println("these should be deeply equal")
+		log.Println(event)
+		log.Println(expectedEvent)
+		t.FailNow()
+	}
+}
+
+func TestFetchEventList(t *testing.T) {
+	eventList := events.EventList()
+	expectedEventList := testEventTypeList
+
+	if !reflect.DeepEqual(eventList, expectedEventList) {
+		log.Println("these should be deeply equal")
+		log.Println(eventList)
+		log.Println(expectedEventList)
+		t.FailNow()
+	}
+}

--- a/test/chaincode_test.go
+++ b/test/chaincode_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/goledgerdev/cc-tools/assets"
 	"github.com/goledgerdev/cc-tools/errors"
+	"github.com/goledgerdev/cc-tools/events"
 	tx "github.com/goledgerdev/cc-tools/transactions"
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
@@ -229,6 +230,17 @@ var testCustomDataTypes = map[string]assets.DataType{
 
 			return cpf, cpf, nil
 		},
+	},
+}
+
+var testEventTypeList = []events.Event{
+	{
+		Tag:         "createLibraryLog",
+		Label:       "Create Library Log",
+		Description: "Log of a library creation",
+		Type:        events.EventLog,
+		BaseLog:     "New library created",
+		Receivers:   []string{"$org1MSP", "$orgMSP"},
 	},
 }
 

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/goledgerdev/cc-tools/assets"
+	"github.com/goledgerdev/cc-tools/events"
 	tx "github.com/goledgerdev/cc-tools/transactions"
 )
 
@@ -24,6 +25,8 @@ func TestMain(m *testing.M) {
 	})
 
 	tx.InitTxList(testTxList)
+
+	events.InitEventList(testEventTypeList)
 
 	err := assets.CustomDataTypes(testCustomDataTypes)
 	if err != nil {

--- a/test/tx_getTx_test.go
+++ b/test/tx_getTx_test.go
@@ -67,6 +67,16 @@ func TestGetTx(t *testing.T) {
 			"tag":         "getDataTypes",
 		},
 		map[string]interface{}{
+			"description": "GetEvents returns the events map",
+			"label":       "Get Events",
+			"tag":         "getEvents",
+		},
+		map[string]interface{}{
+			"description": "ExecuteEvent executes an event of type 'EventCustom'",
+			"label":       "Execute Event",
+			"tag":         "executeEvent",
+		},
+		map[string]interface{}{
 			"description": "",
 			"label":       "Read Asset",
 			"tag":         "readAsset",

--- a/test/tx_getTx_test.go
+++ b/test/tx_getTx_test.go
@@ -77,6 +77,11 @@ func TestGetTx(t *testing.T) {
 			"tag":         "executeEvent",
 		},
 		map[string]interface{}{
+			"description": "RunEvent runs an event of type 'EventCustom' as readOnly",
+			"label":       "Run Event",
+			"tag":         "runEvent",
+		},
+		map[string]interface{}{
 			"description": "",
 			"label":       "Read Asset",
 			"tag":         "readAsset",

--- a/transactions/executeEvent.go
+++ b/transactions/executeEvent.go
@@ -50,7 +50,7 @@ var ExecuteEvent = Transaction{
 			return nil, errors.NewCCError("event is not of type 'EventCustom'", http.StatusBadRequest)
 		}
 
-		err := event.CustomFunction(payload)
+		err := event.CustomFunction(stub, payload)
 		if err != nil {
 			return nil, errors.WrapError(err, "error executing custom function")
 		}

--- a/transactions/executeEvent.go
+++ b/transactions/executeEvent.go
@@ -1,0 +1,57 @@
+package transactions
+
+import (
+	b64 "encoding/base64"
+	"net/http"
+
+	"github.com/goledgerdev/cc-tools/errors"
+	"github.com/goledgerdev/cc-tools/events"
+	sw "github.com/goledgerdev/cc-tools/stubwrapper"
+)
+
+// ExecuteEvent executes an event of type "EventCustom"
+var ExecuteEvent = Transaction{
+	Tag:         "executeEvent",
+	Label:       "Execute Event",
+	Description: "ExecuteEvent executes an event of type 'EventCustom'",
+	Method:      "GET",
+
+	ReadOnly: true,
+	MetaTx:   true,
+	Args: ArgList{
+		{
+			Tag:         "eventTag",
+			Description: "Event Tag",
+			DataType:    "string",
+			Required:    true,
+		},
+		{
+			Tag:         "payload",
+			Description: "Paylod in Base64 encoding",
+			DataType:    "string",
+			Required:    true,
+		},
+	},
+	Routine: func(stub *sw.StubWrapper, req map[string]interface{}) ([]byte, errors.ICCError) {
+		var payload []byte
+
+		payloadEncoded, ok := req["payload"].(string)
+		if ok {
+			payloadDecoded, er := b64.StdEncoding.DecodeString(payloadEncoded)
+			if er != nil {
+				return nil, errors.WrapError(er, "error decoding payload")
+			}
+
+			payload = payloadDecoded
+		}
+		event := events.FetchEvent(req["eventTag"].(string))
+
+		if event.Type != events.EventCustom {
+			return nil, errors.NewCCError("event is not of type 'EventCustom'", http.StatusBadRequest)
+		}
+
+		event.CustomFunction(payload)
+
+		return nil, nil
+	},
+}

--- a/transactions/executeEvent.go
+++ b/transactions/executeEvent.go
@@ -14,7 +14,7 @@ var ExecuteEvent = Transaction{
 	Tag:         "executeEvent",
 	Label:       "Execute Event",
 	Description: "ExecuteEvent executes an event of type 'EventCustom'",
-	Method:      "GET",
+	Method:      "POST",
 
 	ReadOnly: true,
 	MetaTx:   true,

--- a/transactions/executeEvent.go
+++ b/transactions/executeEvent.go
@@ -50,7 +50,10 @@ var ExecuteEvent = Transaction{
 			return nil, errors.NewCCError("event is not of type 'EventCustom'", http.StatusBadRequest)
 		}
 
-		event.CustomFunction(payload)
+		err := event.CustomFunction(payload)
+		if err != nil {
+			return nil, errors.WrapError(err, "error executing custom function")
+		}
 
 		return nil, nil
 	},

--- a/transactions/getEvents.go
+++ b/transactions/getEvents.go
@@ -1,0 +1,31 @@
+package transactions
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/goledgerdev/cc-tools/errors"
+	"github.com/goledgerdev/cc-tools/events"
+	sw "github.com/goledgerdev/cc-tools/stubwrapper"
+)
+
+// GetEvents returns the events map
+var GetEvents = Transaction{
+	Tag:         "getEvents",
+	Label:       "Get Events",
+	Description: "GetEvents returns the events map",
+	Method:      "GET",
+
+	ReadOnly: true,
+	MetaTx:   true,
+	Args:     ArgList{},
+	Routine: func(stub *sw.StubWrapper, req map[string]interface{}) ([]byte, errors.ICCError) {
+		eventList := events.EventList()
+
+		eventListBytes, err := json.Marshal(eventList)
+		if err != nil {
+			return nil, errors.WrapErrorWithStatus(err, "error marshaling event list", http.StatusInternalServerError)
+		}
+		return eventListBytes, nil
+	},
+}

--- a/transactions/runEvent.go
+++ b/transactions/runEvent.go
@@ -9,14 +9,15 @@ import (
 	sw "github.com/goledgerdev/cc-tools/stubwrapper"
 )
 
-// ExecuteEvent executes an event of type "EventCustom"
-var ExecuteEvent = Transaction{
-	Tag:         "executeEvent",
-	Label:       "Execute Event",
-	Description: "ExecuteEvent executes an event of type 'EventCustom'",
-	Method:      "POST",
+// RunEvent runs an event of type "EventCustom" as readOnly
+var RunEvent = Transaction{
+	Tag:         "runEvent",
+	Label:       "Run Event",
+	Description: "RunEvent runs an event of type 'EventCustom' as readOnly",
+	Method:      "GET",
 
-	MetaTx: true,
+	ReadOnly: true,
+	MetaTx:   true,
 	Args: ArgList{
 		{
 			Tag:         "eventTag",

--- a/transactions/txList.go
+++ b/transactions/txList.go
@@ -9,6 +9,7 @@ var basicTxs = []Transaction{
 	GetHeader,
 	GetSchema,
 	GetDataTypes,
+	GetEvents,
 	ReadAsset,
 	ReadAssetHistory,
 	Search,

--- a/transactions/txList.go
+++ b/transactions/txList.go
@@ -11,6 +11,7 @@ var basicTxs = []Transaction{
 	GetDataTypes,
 	GetEvents,
 	ExecuteEvent,
+	RunEvent,
 	ReadAsset,
 	ReadAssetHistory,
 	Search,

--- a/transactions/txList.go
+++ b/transactions/txList.go
@@ -10,6 +10,7 @@ var basicTxs = []Transaction{
 	GetSchema,
 	GetDataTypes,
 	GetEvents,
+	ExecuteEvent,
 	ReadAsset,
 	ReadAssetHistory,
 	Search,


### PR DESCRIPTION
Add event funcionality with 3 types of events:
- `EventLog`: Simply log the event on the CCAPI. Can log the `BaseLog` argument and receive a string marshaled as the payload for additional logging
- `EventTransaction`: Calls a transaction upon receiving. The `Channel` and `Chaincode` options can be used for external CCs, defaulting to the callers own if not specified. The event payload is used as the arguments for the transaction.
- `EventCustom`: Executes a custom function upon calling. This function receives the stub and the event payload as arguments and returns an error.

Common options for events:
- `BaseLog`: Logged upon receiving
- `Receivers`: Define the orgs that will wait for the event

Additional transactions:
- `getEvents`: Returns a list of events registered on the system
- `executeEvent`: Run the custom function for EventCustom

Obs:
- I couldn't create the call event tests, but I can try some other things if deemed essential